### PR TITLE
For datastream we NEED a create event.

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -172,7 +172,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 
 	private void serializeIndexString(JsonGenerator gen, T event) throws IOException {
 		gen.writeStartObject();
-		gen.writeObjectFieldStart("index");
+		gen.writeObjectFieldStart("create");
 		gen.writeObjectField("_index", indexPattern.encode(event));
 		String type = settings.getType();
 		if (type != null) {


### PR DESCRIPTION
Also there is no reason for using an index event for logging, create seems a better fit.
You will not update logging which is the difference between index and create.