### PR TITLE
added enum values for update & delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In your `logback.xml`:
             <authentication class="com.agido.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
             <objectSerialization>true</objectSerialization> <!-- optional (default false) -->
             <keyPrefix>data.</keyPrefix> <!-- optional (default None) -->
-            <operation>index</operation> <!-- optional (supported: index, create - default create) -->
+            <operation>index</operation> <!-- optional (supported: index, create, update, delete - default create) -->
             
             <properties>
                 <!-- please note that <property> tags are also supported, esProperty was added for logback-1.3 compatibility -->
@@ -119,7 +119,8 @@ Configuration Reference
  * `maxMessageSize` (optional, default -1): If set to a number greater than 0, truncate messages larger than this length, then append "`..`" to denote that the message was truncated
  * `authentication` (optional): Add the ability to send authentication headers (see below)
  * `objectSerialization` (optional): specifies whether to use POJO to JSON serialization 
- * `keyPrefix` (optional): objects logged within a message will also be logged separately with this prefix added  
+ * `keyPrefix` (optional): objects logged within a message will also be logged separately with this prefix added
+ * `operation` (optional, default create): Possible values are: `index`, `create`, `update` & `delete`, see the Elasticsearch [Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) documentation for more information
 
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<esProperty>` elements to the `<properties>` set.
 

--- a/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -169,7 +169,13 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
         settings.setAutoStackTraceLevel(level);
     }
 
-    public void setOperation(String operation) {
-        settings.setOperation( Operation.of( operation ).orElse( Operation.CREATE ) );
+    public void setOperation( String operation ) {
+        settings.setOperation( Operation.of( operation )
+                .orElseGet(
+                    () -> {
+                        addWarn( "Invalid value provided for [operation] setting, assuming CREATE" );
+                        return Operation.CREATE;
+                    } )
+            );
     }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -1,6 +1,5 @@
 package com.agido.logback.elasticsearch;
 
-import ch.qos.logback.classic.Level;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import com.agido.logback.elasticsearch.config.Authentication;
 import com.agido.logback.elasticsearch.config.ElasticsearchProperties;
@@ -173,8 +172,8 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
         settings.setOperation( Operation.of( operation )
                 .orElseGet(
                     () -> {
-                        addWarn( "Invalid value provided for [operation] setting, assuming CREATE" );
-                        return Operation.CREATE;
+                        addWarn( "Invalid value provided for [operation] setting, assuming create" );
+                        return Operation.create;
                     } )
             );
     }

--- a/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -195,7 +195,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 
     private void serializeIndexString(JsonGenerator gen, T event) throws IOException {
         gen.writeStartObject();
-        gen.writeObjectFieldStart(settings.getOperation().getLabel());
+        gen.writeObjectFieldStart(settings.getOperation().name());
         gen.writeObjectField("_index", indexPattern.encode(event));
         String type = settings.getType();
         if (type != null) {

--- a/src/main/java/com/agido/logback/elasticsearch/config/Operation.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/Operation.java
@@ -1,42 +1,22 @@
 package com.agido.logback.elasticsearch.config;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 /**
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html">Bulk API actions</a>
  */
 public enum Operation {
-    INDEX( "index" ),
-    CREATE( "create" ),
-    UPDATE( "update" ),
-    DELETE( "delete" );
-
-    private final String label;
-
-    Operation( String label ) {
-        this.label = label;
-    }
-
-    private final static Map<String, Operation> cache;
-    static {
-        cache = new HashMap<>();
-        for (Operation operation : values()) {
-            cache.put(operation.name(), operation);
-            cache.put(operation.label, operation);
-        }
-    }
-
-    static Operation valueOfMap(String value) {
-        return cache.get(value);
-    }
+    index,
+    create,
+    update,
+    delete;
 
     public static Optional<Operation> of( String value ) {
-        return Optional.ofNullable( valueOfMap( value ) );
-    }
+        try {
+            return Optional.of( valueOf( value ) );
+        } catch ( IllegalArgumentException ignored ) {
+        }
 
-    public String getLabel() {
-        return this.label;
+        return Optional.empty( );
     }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/config/Operation.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/Operation.java
@@ -1,11 +1,17 @@
 package com.agido.logback.elasticsearch.config;
 
-import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
+/**
+ * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html">Bulk API actions</a>
+ */
 public enum Operation {
     INDEX( "index" ),
-    CREATE( "create" );
+    CREATE( "create" ),
+    UPDATE( "update" ),
+    DELETE( "delete" );
 
     private final String label;
 
@@ -13,14 +19,24 @@ public enum Operation {
         this.label = label;
     }
 
-    public String getLabel() {
-        return this.label;
+    private final static Map<String, Operation> cache;
+    static {
+        cache = new HashMap<>();
+        for (Operation operation : values()) {
+            cache.put(operation.name(), operation);
+            cache.put(operation.label, operation);
+        }
     }
 
-    public static Optional<Operation> of( String label ) {
-        return EnumSet.allOf( Operation.class )
-                      .stream()
-                      .filter( op -> op.label.equalsIgnoreCase( label ) )
-                      .findFirst();
+    static Operation valueOfMap(String value) {
+        return cache.get(value);
+    }
+
+    public static Optional<Operation> of( String value ) {
+        return Optional.ofNullable( valueOfMap( value ) );
+    }
+
+    public String getLabel() {
+        return this.label;
     }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/Settings.java
@@ -28,7 +28,7 @@ public class Settings {
     private String keyPrefix;
     private boolean objectSerialization;
     private Level autoStackTraceLevel = Level.OFF;
-    private Operation operation = Operation.CREATE;
+    private Operation operation = Operation.create;
 
     public String getIndex() {
         return index;


### PR DESCRIPTION
This PR adds keys for update & delete operations, although these might not be sensible in the current context https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html

The enum value lookup was implemented in a suboptimal way, which has been improved with a HashMap cache
see  https://github.com/jorimvanhove/operation-enum-micro-optimizations

Also added a warning when the operation input is invalid
> 11:08:38,785 |-WARN in com.agido.logback.elasticsearch.ElasticsearchAppender[elk-errors] - Invalid value provided for [operation] setting, assuming CREATE
