### PR TITLE
Update version of Mockito to make tests compatible with JDK 17+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/com/agido/logback/elasticsearch/ElasticsearchAppenderTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/ElasticsearchAppenderTest.java
@@ -11,14 +11,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -100,7 +100,7 @@ public class ElasticsearchAppenderTest {
 
         appender.append(eventToLog);
 
-        verifyZeroInteractions(elasticsearchPublisher);
+        verifyNoInteractions(elasticsearchPublisher);
     }
 
 
@@ -117,7 +117,7 @@ public class ElasticsearchAppenderTest {
 
         appender.append(eventToLog);
 
-        verifyZeroInteractions(elasticsearchPublisher);
+        verifyNoInteractions(elasticsearchPublisher);
     }
 
 

--- a/src/test/java/com/agido/logback/elasticsearch/PropertySerializerTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/PropertySerializerTest.java
@@ -8,10 +8,10 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)


### PR DESCRIPTION
Tests currently pass with JDK 8/11, but fail with JDK 17+, because the Mockito version used is not compatible with newer JDKs.

This updates the version of Mockito to make tests compatible with JDK 17+ and switches from mockito-all to mockito-core - mockito-all is deprecated. Updated to mockito-core 4.x, because 5.x introduces changes that alter which method calls are detected and requires more extensive test changes.