### PR TITLE
fixed: 401 error occurs when  the password or username with characters such as @, # fixed: Some time es bluk happened timestamp parse error， so that to set the format of @timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In your `logback.xml`:
             <objectSerialization>true</objectSerialization> <!-- optional (default false) -->
             <keyPrefix>data.</keyPrefix> <!-- optional (default None) -->
             <operation>index</operation> <!-- optional (supported: index, create, update, delete - default create) -->
-            
+            <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSZ</timestampFormat>  <!-- optional (default None  if set long to the timestamp milliseconds long value) -->
             <properties>
                 <!-- please note that <property> tags are also supported, esProperty was added for logback-1.3 compatibility -->
                 <esProperty>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
     </developers>
 
     <properties>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.14</version>
+            <version>1.4.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-access</artifactId>
-            <version>1.3.14</version>
+            <version>1.4.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,13 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.14</version>
+            <version>1.3.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-access</artifactId>
-            <version>1.4.14</version>
+            <version>1.3.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -143,6 +143,9 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
     public void setRawJsonMessage(boolean rawJsonMessage) {
         settings.setRawJsonMessage(rawJsonMessage);
     }
+    public void setTimestampFormat(String timestampFormat) {
+        settings.setTimestampFormat(timestampFormat);
+    }
 
     public void setIncludeMdc(boolean includeMdc) {
         settings.setIncludeMdc(includeMdc);

--- a/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
@@ -2,12 +2,19 @@ package com.agido.logback.elasticsearch.config;
 
 import com.agido.logback.elasticsearch.util.Base64;
 
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.URLDecoder;
 
 public class BasicAuthentication implements Authentication {
     public void addAuth(HttpURLConnection urlConnection, String body) {
         String userInfo = urlConnection.getURL().getUserInfo();
         if (userInfo != null) {
+            try {
+                userInfo = URLDecoder.decode(userInfo,"UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
             String basicAuth = "Basic " + Base64.encode(userInfo.getBytes());
             urlConnection.setRequestProperty("Authorization", basicAuth);
         }

--- a/src/main/java/com/agido/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/Settings.java
@@ -30,6 +30,8 @@ public class Settings {
     private Level autoStackTraceLevel = Level.OFF;
     private Operation operation = Operation.create;
 
+    private String timestampFormat;
+
     public String getIndex() {
         return index;
     }
@@ -67,6 +69,18 @@ public class Settings {
 
     public int getMaxRetries() {
         return maxRetries;
+    }
+
+    public void setAutoStackTraceLevel(Level autoStackTraceLevel) {
+        this.autoStackTraceLevel = autoStackTraceLevel;
+    }
+
+    public String getTimestampFormat() {
+        return timestampFormat;
+    }
+
+    public void setTimestampFormat(String timestampFormat) {
+        this.timestampFormat = timestampFormat;
     }
 
     public void setMaxRetries(int maxRetries) {


### PR DESCRIPTION
fixed: 401 error occurs when  the password or username with characters such as @, #
fixed: Some time es bluk happened timestamp parse error， so that to set the format of @timestamp