### PR TITLE
Add support for key-value-pairs set via fluent api

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ In your `logback.xml`:
             <sleepTime>250</sleepTime> <!-- optional (in ms, default 250) -->
             <rawJsonMessage>false</rawJsonMessage> <!-- optional (default false) -->
             <includeMdc>false</includeMdc> <!-- optional (default false) -->
+            <includeKvp>false</includeKvp> <!-- optional (default false) -->
             <maxMessageSize>100</maxMessageSize> <!-- optional (default -1 -->
             <authentication class="com.agido.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
             <objectSerialization>true</objectSerialization> <!-- optional (default false) -->
@@ -116,6 +117,7 @@ Configuration Reference
  * `errorLoggerName` (optional): If set, any internal errors or problems will be logged to this logger
  * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message.
  * `includeMdc` (optional, default false): If set to `true`, then all [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values will be mapped to properties on the JSON payload.
+ * `includeKvp` (optional, default false): If set to `true`, then all key-value-pairs set via [LoggingEventBuilder](https://slf4j.org/api/org/slf4j/spi/LoggingEventBuilder.html) using the [Fluent API](https://slf4j.org/manual.html#fluent) will be mapped to properties on the JSON payload.
  * `maxMessageSize` (optional, default -1): If set to a number greater than 0, truncate messages larger than this length, then append "`..`" to denote that the message was truncated
  * `authentication` (optional): Add the ability to send authentication headers (see below)
  * `objectSerialization` (optional): specifies whether to use POJO to JSON serialization 

--- a/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -180,4 +180,8 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
                     } )
             );
     }
+
+    public void setIncludeKvp(boolean includeKvp) {
+      settings.setIncludeKvp(includeKvp);
+    }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/ClassicElasticsearchPublisher.java
+++ b/src/main/java/com/agido/logback/elasticsearch/ClassicElasticsearchPublisher.java
@@ -10,9 +10,10 @@ import com.agido.logback.elasticsearch.util.AbstractPropertyAndEncoder;
 import com.agido.logback.elasticsearch.util.ClassicPropertyAndEncoder;
 import com.agido.logback.elasticsearch.util.ErrorReporter;
 import com.fasterxml.jackson.core.JsonGenerator;
+import org.slf4j.event.KeyValuePair;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.*;
 
 public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublisher<ILoggingEvent> {
 
@@ -44,6 +45,15 @@ public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublishe
             for (Map.Entry<String, String> entry : event.getMDCPropertyMap().entrySet()) {
                 gen.writeObjectField(entry.getKey(), entry.getValue());
             }
+        }
+
+        if (settings.isIncludeKvp()) {
+          final List<KeyValuePair> kvps = event.getKeyValuePairs() != null ? event.getKeyValuePairs() : Collections.emptyList();
+          for (KeyValuePair kvp : kvps) {
+            if (kvp != null) {
+              gen.writeObjectField(kvp.key, kvp.value);
+            }
+          }
         }
     }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/Settings.java
@@ -29,6 +29,7 @@ public class Settings {
     private boolean objectSerialization;
     private Level autoStackTraceLevel = Level.OFF;
     private Operation operation = Operation.create;
+    private boolean includeKvp;
 
     private String timestampFormat;
 
@@ -213,5 +214,13 @@ public class Settings {
 
     public Level getAutoStackTraceLevel() {
         return autoStackTraceLevel;
+    }
+
+    public boolean isIncludeKvp() {
+      return includeKvp;
+    }
+
+    public void setIncludeKvp(boolean includeKvp) {
+      this.includeKvp = includeKvp;
     }
 }

--- a/src/test/java/com/agido/logback/elasticsearch/ElasticsearchAppenderTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/ElasticsearchAppenderTest.java
@@ -186,6 +186,7 @@ public class ElasticsearchAppenderTest {
         int aSleepTime = 10000;
         int readTimeout = 10000;
         int connectTimeout = 5000;
+        boolean includeKvp = true;
 
         appender.setIncludeCallerData(includeCallerData);
         appender.setSleepTime(aSleepTime);
@@ -202,6 +203,7 @@ public class ElasticsearchAppenderTest {
         appender.setConnectTimeout(connectTimeout);
         appender.setRawJsonMessage(rawJsonMessage);
         appender.setIncludeMdc(includeMdc);
+        appender.setIncludeKvp(includeKvp);
 
         verify(settings, times(1)).setReadTimeout(readTimeout);
         verify(settings, times(1)).setSleepTime(aSleepTime);
@@ -218,6 +220,7 @@ public class ElasticsearchAppenderTest {
         verify(settings, times(1)).setConnectTimeout(connectTimeout);
         verify(settings, times(1)).setRawJsonMessage(rawJsonMessage);
         verify(settings, times(1)).setIncludeMdc(includeMdc);
+        verify(settings, times(1)).setIncludeKvp(includeKvp);
     }
 
 


### PR DESCRIPTION
An alternative approach to logging structured data per message is to use the LoggingFramework's Fluent API instead of the MDC. This data is then included as key-value pairs in the LoggingEvent. This PR adds support for publishing these key-value pairs to elasticsearch.