### PR TITLE
Add automatic jackson module registration

### DIFF
--- a/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/agido/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -94,6 +94,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
     private JsonFactory buildJsonFactory(Settings settings) {
         if (settings.isObjectSerialization()) {
             ObjectMapper mapper = new ObjectMapper();
+            mapper.findAndRegisterModules();
             return mapper.getFactory();
         }
         return new JsonFactory();


### PR DESCRIPTION
If the `objectSerialization=true` option is used, the JsonFactory of a Jackson ObjectMapper is used internally instead of instantiating a simple JsonFactory. Serialization may fail if certain Jackson modules are not registered with the ObjectMapper, such as the `Jdk8Module` for serializing `java.util.Optional` or the `JavaTimeModule` for serializing `java.time.Duration`. Since there is no way to directly influence the ObjectMapper, this change adds the use of the automatic registration mechanism, thus registering all modules found in the classpath, provided the `objectSerialization=true` option is set.