### PR TITLE
Fix: Special characters in Basic Authentication credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Authentication
 Authentication is a pluggable mechanism. You must specify the authentication class on the XML element itself. The currently supported classes are:
 
 * `com.agido.logback.elasticsearch.config.BasicAuthentication` - Supports two configuration methods:
-  * **Recommended**: Use `<username>` and `<password>` elements (special characters work without encoding):
+  * **Recommended**: Use `<username>` and `<password>` elements (no URL-encoding required):
     ```xml
     <authentication class="com.agido.logback.elasticsearch.config.BasicAuthentication">
         <username>myuser</username>

--- a/README.md
+++ b/README.md
@@ -157,7 +157,18 @@ Authentication
 
 Authentication is a pluggable mechanism. You must specify the authentication class on the XML element itself. The currently supported classes are:
 
-* `com.agido.logback.elasticsearch.config.BasicAuthentication` - Username and password are taken from the URL (i.e. `http://username:password@yourserver/_bulk`)
+* `com.agido.logback.elasticsearch.config.BasicAuthentication` - Supports two configuration methods:
+  * **Recommended**: Use `<username>` and `<password>` elements (special characters work without encoding):
+    ```xml
+    <authentication class="com.agido.logback.elasticsearch.config.BasicAuthentication">
+        <username>myuser</username>
+        <password>p@ss€word#123</password>
+    </authentication>
+    ```
+  * **Legacy**: Credentials in URL (special characters must be URL-encoded, e.g., `@` → `%40`):
+    ```xml
+    <url>http://user:p%40ssword@yourserver/_bulk</url>
+    ```
 * `com.agido.logback.elasticsearch.config.AWSAuthentication` - Authenticate using the AWS SDK, for use with the [Amazon Elasticsearch Service](https://aws.amazon.com/elasticsearch-service/) (note that you will also need to include `com.amazonaws:aws-java-sdk-core` as a dependency)
 
 Logback Access

--- a/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
@@ -8,16 +8,28 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 
 public class BasicAuthentication implements Authentication {
+    
+    private volatile String cachedAuthHeader;
+    
     public void addAuth(HttpURLConnection urlConnection, String body) {
-        String userInfo = urlConnection.getURL().getUserInfo();
-        if (userInfo != null) {
-            try {
-                userInfo = URLDecoder.decode(userInfo, StandardCharsets.UTF_8.name());
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
-            String basicAuth = "Basic " + Base64.encode(userInfo.getBytes(StandardCharsets.UTF_8));
-            urlConnection.setRequestProperty("Authorization", basicAuth);
+        if (cachedAuthHeader == null) {
+            cachedAuthHeader = buildAuthHeader(urlConnection);
         }
+        if (cachedAuthHeader != null) {
+            urlConnection.setRequestProperty("Authorization", cachedAuthHeader);
+        }
+    }
+    
+    private String buildAuthHeader(HttpURLConnection urlConnection) {
+        String userInfo = urlConnection.getURL().getUserInfo();
+        if (userInfo == null) {
+            return null;
+        }
+        try {
+            userInfo = URLDecoder.decode(userInfo, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+        return "Basic " + Base64.encode(userInfo.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
@@ -10,6 +10,16 @@ import java.nio.charset.StandardCharsets;
 public class BasicAuthentication implements Authentication {
     
     private volatile String cachedAuthHeader;
+    private String username;
+    private String password;
+    
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public void setPassword(String password) {
+        this.password = password;
+    }
     
     public void addAuth(HttpURLConnection urlConnection, String body) {
         if (cachedAuthHeader == null) {
@@ -21,15 +31,24 @@ public class BasicAuthentication implements Authentication {
     }
     
     private String buildAuthHeader(HttpURLConnection urlConnection) {
-        String userInfo = urlConnection.getURL().getUserInfo();
-        if (userInfo == null) {
-            return null;
+        String credentials;
+        
+        // Prefer explicit username/password config
+        if (username != null && password != null) {
+            credentials = username + ":" + password;
+        } else {
+            // Fallback to URL userInfo (backward compatible)
+            String userInfo = urlConnection.getURL().getUserInfo();
+            if (userInfo == null) {
+                return null;
+            }
+            try {
+                credentials = URLDecoder.decode(userInfo, StandardCharsets.UTF_8.name());
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
         }
-        try {
-            userInfo = URLDecoder.decode(userInfo, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-        return "Basic " + Base64.encode(userInfo.getBytes(StandardCharsets.UTF_8));
+        
+        return "Basic " + Base64.encode(credentials.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
@@ -5,17 +5,18 @@ import com.agido.logback.elasticsearch.util.Base64;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 public class BasicAuthentication implements Authentication {
     public void addAuth(HttpURLConnection urlConnection, String body) {
         String userInfo = urlConnection.getURL().getUserInfo();
         if (userInfo != null) {
             try {
-                userInfo = URLDecoder.decode(userInfo,"UTF-8");
+                userInfo = URLDecoder.decode(userInfo, StandardCharsets.UTF_8.name());
             } catch (UnsupportedEncodingException e) {
                 throw new RuntimeException(e);
             }
-            String basicAuth = "Basic " + Base64.encode(userInfo.getBytes());
+            String basicAuth = "Basic " + Base64.encode(userInfo.getBytes(StandardCharsets.UTF_8));
             urlConnection.setRequestProperty("Authorization", basicAuth);
         }
     }

--- a/src/test/java/com/agido/logback/elasticsearch/config/BasicAuthenticationTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/config/BasicAuthenticationTest.java
@@ -18,8 +18,29 @@ import static org.mockito.Mockito.*;
 public class BasicAuthenticationTest {
 
     @Test
-    public void should_encode_credentials_with_special_characters_using_utf8() throws Exception {
-        // Given: URL with special characters in password (e.g., @, €, ö, #)
+    public void should_encode_credentials_with_special_characters_using_explicit_username_password() throws Exception {
+        // Given: explicit username/password with special characters
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+
+        BasicAuthentication auth = new BasicAuthentication();
+        auth.setUsername("user");
+        auth.setPassword("p@ss€wörd#123");
+
+        // When
+        auth.addAuth(mockConnection, "");
+
+        // Then: verify credentials are encoded with UTF-8
+        ArgumentCaptor<String> headerValue = ArgumentCaptor.forClass(String.class);
+        verify(mockConnection).setRequestProperty(eq("Authorization"), headerValue.capture());
+
+        String expectedCredentials = "user:p@ss€wörd#123";
+        String expectedBase64 = Base64.getEncoder().encodeToString(expectedCredentials.getBytes(StandardCharsets.UTF_8));
+        assertThat(headerValue.getValue(), is("Basic " + expectedBase64));
+    }
+
+    @Test
+    public void should_fallback_to_url_credentials_when_username_password_not_set() throws Exception {
+        // Given: URL with URL-encoded special characters (legacy mode)
         URL testUrl = new URL("http://user:p%40ss%E2%82%ACw%C3%B6rd%23123@localhost:9200");
         
         HttpURLConnection mockConnection = mock(HttpURLConnection.class);
@@ -30,7 +51,7 @@ public class BasicAuthenticationTest {
         // When
         auth.addAuth(mockConnection, "");
 
-        // Then: verify credentials are encoded with UTF-8
+        // Then: verify credentials are decoded and encoded with UTF-8
         ArgumentCaptor<String> headerValue = ArgumentCaptor.forClass(String.class);
         verify(mockConnection).setRequestProperty(eq("Authorization"), headerValue.capture());
 

--- a/src/test/java/com/agido/logback/elasticsearch/config/BasicAuthenticationTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/config/BasicAuthenticationTest.java
@@ -1,0 +1,41 @@
+package com.agido.logback.elasticsearch.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BasicAuthenticationTest {
+
+    @Test
+    public void should_encode_credentials_with_special_characters_using_utf8() throws Exception {
+        // Given: URL with special characters in password (e.g., @, €, ö, #)
+        URL testUrl = new URL("http://user:p%40ss%E2%82%ACw%C3%B6rd%23123@localhost:9200");
+        
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getURL()).thenReturn(testUrl);
+
+        BasicAuthentication auth = new BasicAuthentication();
+
+        // When
+        auth.addAuth(mockConnection, "");
+
+        // Then: verify credentials are encoded with UTF-8
+        ArgumentCaptor<String> headerValue = ArgumentCaptor.forClass(String.class);
+        verify(mockConnection).setRequestProperty(eq("Authorization"), headerValue.capture());
+
+        String expectedCredentials = "user:p@ss€wörd#123";
+        String expectedBase64 = Base64.getEncoder().encodeToString(expectedCredentials.getBytes(StandardCharsets.UTF_8));
+        assertThat(headerValue.getValue(), is("Basic " + expectedBase64));
+    }
+}


### PR DESCRIPTION
1.  Explicitly use UTF-8 encoding via StandardCharsets.UTF_8 for Base64 encoding of credentials
2.  Cache the computed header after the first call
3. Add explicit username/password configuration
