### PR TITLE
Upgrade to Java 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
     - name: Test with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,7 @@
 	</developers>
 
 	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -117,8 +116,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.10.1</version>
 				<configuration>
-					<source>${maven.compiler.source}</source>
-					<target>${maven.compiler.target}</target>
+					<release>11</release>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Addresses the Java 11 upgrade requested in #45 (the `java.net.http.HttpClient` refactor is a separate follow-up PR).

Migrates the build from Java 8 to Java 11 (via OpenRewrite `Java8toJava11`):
- compiler `source`/`target` 1.8 → `<release>11</release>`
- JDK 8 → 11 in the CI workflow

Verified locally: `mvn test` (the project's CI command) is green under Temurin 11 — all 24 previously-passing tests still pass (no test lost).

*Prepared with the open-source [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.*
