### PR TITLE
Use java.net.http.HttpClient + AWS SDK v2 for connection pooling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
     - name: Test with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,7 @@
 	</developers>
 
 	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -117,8 +116,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.10.1</version>
 				<configuration>
-					<source>${maven.compiler.source}</source>
-					<target>${maven.compiler.target}</target>
+					<release>11</release>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,18 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>2.28.16</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
@@ -84,9 +96,13 @@
 			<version>2.14.1</version>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-core</artifactId>
-			<version>1.12.350</version>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>auth</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>regions</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -104,6 +120,12 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>4.11.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
+			<version>2.35.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/agido/logback/elasticsearch/config/AWSAuthentication.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/AWSAuthentication.java
@@ -1,148 +1,88 @@
 package com.agido.logback.elasticsearch.config;
 
-import com.amazonaws.ReadLimitInfo;
-import com.amazonaws.SignableRequest;
-import com.amazonaws.auth.AWS4Signer;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.http.HttpMethodName;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.util.StringInputStream;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
+import java.io.ByteArrayInputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 
 /**
- * This class implements Amazon AWS v4 Signature signing for ElasticSearch.
+ * This class implements Amazon AWS v4 Signature signing for ElasticSearch,
+ * using the AWS SDK v2.
  *
  * @author blagerweij
  */
 public class AWSAuthentication implements Authentication {
 
-    private final AWS4Signer signer;
-    private final AWSCredentials credentials;
+    private final Aws4Signer signer;
+    private final AwsCredentialsProvider credentialsProvider;
+    private final String region;
+    private final Clock clock;
 
     public AWSAuthentication() {
-        signer = new AWS4Signer(false);
-        signer.setServiceName("es");
-        signer.setRegionName(getCurrentRegion());
-        AWSCredentialsProvider credsProvider = new DefaultAWSCredentialsProviderChain();
-        credentials = credsProvider.getCredentials();
-    }
-
-    @Override
-    public void addAuth(HttpURLConnection urlConnection, String body) {
-
-        signer.sign(new URLConnectionSignableRequest(urlConnection, body), credentials);
-    }
-
-    private String getCurrentRegion() {
-        if (Regions.getCurrentRegion() != null) {
-            return Regions.getCurrentRegion().getName();
-        }
-        return null;
+        this(DefaultCredentialsProvider.create(), resolveRegion(), Clock.systemUTC());
     }
 
     /**
-     * Wrapper for signing a HttpURLConnection
+     * Package-private constructor for testing: allows injecting credentials, region and clock.
      */
-    private static class URLConnectionSignableRequest implements SignableRequest<HttpURLConnection> {
+    AWSAuthentication(AwsCredentialsProvider credentialsProvider, Region region, Clock clock) {
+        this.signer = Aws4Signer.create();
+        this.credentialsProvider = credentialsProvider;
+        this.region = region != null ? region.id() : null;
+        this.clock = clock != null ? clock : Clock.systemUTC();
+    }
 
-        private final HttpURLConnection urlConnection;
-        private final String body;
-        private final Map<String, String> headers = new HashMap<>();
-
-        public URLConnectionSignableRequest(HttpURLConnection urlConnection, String body) {
-            this.urlConnection = urlConnection;
-            this.body = body;
-            addHeader("User-Agent", "ElasticSearchWriter/1.0");
-            addHeader("Accept", "*/*");
-            addHeader("Content-Type", "application/json");
-            addHeader("Content-Length", String.valueOf(body.length()));
-        }
-
-        @Override
-        public void addHeader(String name, String value) {
-            this.urlConnection.addRequestProperty(name, value);
-            headers.put(name, value);
-        }
-
-        @Override
-        public Map<String, String> getHeaders() {
-            return headers;
-        }
-
-        @Override
-        public String getResourcePath() {
-            return urlConnection.getURL().getPath();
-        }
-
-        @Override
-        public void addParameter(String name, String value) {
-
-        }
-
-        @Override
-        public Map<String, List<String>> getParameters() {
-            return Collections.emptyMap();
-        }
-
-        @Override
-        public URI getEndpoint() {
-            try {
-                URL u = urlConnection.getURL();
-                return new URI(u.getProtocol(), null, u.getHost(), u.getPort(), null, null, null);
-            } catch (URISyntaxException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        @Override
-        public HttpMethodName getHttpMethod() {
-            return HttpMethodName.fromValue(urlConnection.getRequestMethod());
-        }
-
-        @Override
-        public int getTimeOffset() {
-            return 0;
-        }
-
-        @Override
-        public InputStream getContent() {
-            try {
-                return new StringInputStream(body);
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
-
-        }
-
-        @Override
-        public void setContent(InputStream content) {
-        }
-
-        @Override
-        public InputStream getContentUnwrapped() {
-            return getContent();
-        }
-
-        @Override
-        public ReadLimitInfo getReadLimitInfo() {
+    private static Region resolveRegion() {
+        try {
+            return new DefaultAwsRegionProviderChain().getRegion();
+        } catch (RuntimeException e) {
             return null;
         }
+    }
 
-        @Override
-        public Object getOriginalRequestObject() {
-            return null;
+    @Override
+    public void addAuth(Map<String, String> headers, URI uri, byte[] body) {
+        SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                .method(SdkHttpMethod.POST)
+                .uri(uri)
+                .contentStreamProvider(() -> new ByteArrayInputStream(body))
+                // The "required" token makes the Aws4Signer compute the payload hash, substitute it
+                // here, and include x-amz-content-sha256 in the SignedHeaders set.
+                .putHeader("x-amz-content-sha256", "required")
+                .build();
+
+        Aws4SignerParams params = Aws4SignerParams.builder()
+                .awsCredentials(credentialsProvider.resolveCredentials())
+                .signingRegion(region != null ? Region.of(region) : null)
+                .signingName("es")
+                .signingClockOverride(clock)
+                .build();
+
+        SdkHttpFullRequest signed = signer.sign(request, params);
+
+        copyHeader(signed, headers, "Authorization");
+        copyHeader(signed, headers, "X-Amz-Date");
+        copyHeader(signed, headers, "X-Amz-Content-Sha256");
+        copyHeader(signed, headers, "X-Amz-Security-Token");
+    }
+
+    private void copyHeader(SdkHttpFullRequest signed, Map<String, String> headers, String name) {
+        for (Map.Entry<String, List<String>> entry : signed.headers().entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(name)
+                    && entry.getValue() != null && !entry.getValue().isEmpty()) {
+                headers.put(name, entry.getValue().get(0));
+                return;
+            }
         }
     }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/config/Authentication.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/Authentication.java
@@ -1,13 +1,15 @@
 package com.agido.logback.elasticsearch.config;
 
-import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.Map;
 
 public interface Authentication {
     /**
-     * Modify the given urlConnection for whatever authentication scheme is used.
+     * Add authentication headers for whatever authentication scheme is used.
      *
-     * @param urlConnection the connection to the server
-     * @param body          the message being sent
+     * @param headers the mutable map of request headers; implementations add their auth headers here
+     * @param uri     the request URI (with any userInfo stripped off)
+     * @param body    the exact bytes that will be sent (already gzipped if compression is enabled)
      */
-    void addAuth(HttpURLConnection urlConnection, String body);
+    void addAuth(Map<String, String> headers, URI uri, byte[] body);
 }

--- a/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
+++ b/src/main/java/com/agido/logback/elasticsearch/config/BasicAuthentication.java
@@ -2,53 +2,46 @@ package com.agido.logback.elasticsearch.config;
 
 import com.agido.logback.elasticsearch.util.Base64;
 
-import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
-import java.net.URLDecoder;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 public class BasicAuthentication implements Authentication {
-    
+
     private volatile String cachedAuthHeader;
     private String username;
     private String password;
-    
+
     public void setUsername(String username) {
         this.username = username;
     }
-    
+
     public void setPassword(String password) {
         this.password = password;
     }
-    
-    public void addAuth(HttpURLConnection urlConnection, String body) {
+
+    /**
+     * @return true if both username and password have been configured explicitly.
+     */
+    public boolean hasCredentials() {
+        return username != null && password != null;
+    }
+
+    @Override
+    public void addAuth(Map<String, String> headers, URI uri, byte[] body) {
         if (cachedAuthHeader == null) {
-            cachedAuthHeader = buildAuthHeader(urlConnection);
+            cachedAuthHeader = buildAuthHeader();
         }
         if (cachedAuthHeader != null) {
-            urlConnection.setRequestProperty("Authorization", cachedAuthHeader);
+            headers.put("Authorization", cachedAuthHeader);
         }
     }
-    
-    private String buildAuthHeader(HttpURLConnection urlConnection) {
-        String credentials;
-        
-        // Prefer explicit username/password config
-        if (username != null && password != null) {
-            credentials = username + ":" + password;
-        } else {
-            // Fallback to URL userInfo (backward compatible)
-            String userInfo = urlConnection.getURL().getUserInfo();
-            if (userInfo == null) {
-                return null;
-            }
-            try {
-                credentials = URLDecoder.decode(userInfo, StandardCharsets.UTF_8.name());
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+
+    private String buildAuthHeader() {
+        if (username == null || password == null) {
+            return null;
         }
-        
+        String credentials = username + ":" + password;
         return "Basic " + Base64.encode(credentials.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/agido/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/agido/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -1,15 +1,26 @@
 package com.agido.logback.elasticsearch.writer;
 
+import com.agido.logback.elasticsearch.config.Authentication;
+import com.agido.logback.elasticsearch.config.BasicAuthentication;
 import com.agido.logback.elasticsearch.config.HttpRequestHeader;
 import com.agido.logback.elasticsearch.config.HttpRequestHeaders;
 import com.agido.logback.elasticsearch.config.Settings;
 import com.agido.logback.elasticsearch.util.ErrorReporter;
-import org.apache.http.HttpHeaders;
 
-import java.io.*;
-import java.net.HttpURLConnection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
 public class ElasticsearchWriter implements SafeWriter {
@@ -23,6 +34,8 @@ public class ElasticsearchWriter implements SafeWriter {
     private boolean bufferExceeded;
     private boolean compressedTransfer;
 
+    private final HttpClient httpClient;
+
     public ElasticsearchWriter(ErrorReporter errorReporter, Settings settings, HttpRequestHeaders headers) {
         this.errorReporter = errorReporter;
         this.settings = settings;
@@ -33,11 +46,15 @@ public class ElasticsearchWriter implements SafeWriter {
         this.sendBuffer = new StringBuilder();
         compressedTransfer = false;
         for (HttpRequestHeader header : this.headerList) {
-            if (header.getName().toLowerCase().equals(HttpHeaders.CONTENT_ENCODING.toLowerCase()) && header.getValue().equals("gzip")) {
+            if (header.getName().equalsIgnoreCase("Content-Encoding") && header.getValue().equals("gzip")) {
                 compressedTransfer = true;
                 break;
             }
         }
+
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(settings.getConnectTimeout()))
+                .build();
     }
 
     public void write(char[] cbuf, int off, int len) {
@@ -58,42 +75,53 @@ public class ElasticsearchWriter implements SafeWriter {
             return;
         }
 
-        HttpURLConnection urlConnection = null; 
         try {
-            urlConnection = (HttpURLConnection) (settings.getUrl().openConnection());
-            urlConnection.setDoInput(true);
-            urlConnection.setDoOutput(true);
-            urlConnection.setReadTimeout(settings.getReadTimeout());
-            urlConnection.setConnectTimeout(settings.getConnectTimeout());
-            urlConnection.setRequestMethod("POST");
+            byte[] body = buildBody(sendBuffer.toString());
 
-            String body = sendBuffer.toString();
+            URI rawUri = settings.getUrl().toURI();
+            String userInfo = rawUri.getUserInfo();
+            URI sendUri = stripUserInfo(rawUri);
 
-            if (!headerList.isEmpty()) {
-                for (HttpRequestHeader header : headerList) {
-                    urlConnection.setRequestProperty(header.getName(), header.getValue());
+            Map<String, String> requestHeaders = new LinkedHashMap<>();
+            requestHeaders.put("Content-Type", "application/json");
+            for (HttpRequestHeader header : headerList) {
+                requestHeaders.put(header.getName(), header.getValue());
+            }
+
+            Authentication authentication = settings.getAuthentication();
+            if (authentication != null) {
+                if (userInfo != null && authentication instanceof BasicAuthentication
+                        && !((BasicAuthentication) authentication).hasCredentials()) {
+                    applyUserInfo((BasicAuthentication) authentication, userInfo);
                 }
+                authentication.addAuth(requestHeaders, sendUri, body);
             }
 
-            if (settings.getAuthentication() != null) {
-                settings.getAuthentication().addAuth(urlConnection, body);
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(sendUri)
+                    .timeout(Duration.ofMillis(settings.getReadTimeout()))
+                    .POST(HttpRequest.BodyPublishers.ofByteArray(body));
+            for (Map.Entry<String, String> entry : requestHeaders.entrySet()) {
+                requestBuilder.header(entry.getKey(), entry.getValue());
             }
 
-            writeData(urlConnection, body);
+            HttpResponse<byte[]> response;
+            try {
+                response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofByteArray());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while sending data to server", e);
+            }
 
-            int rc = urlConnection.getResponseCode();
+            int rc = response.statusCode();
 
             if (rc == 200) {
-                // Consume response stream to enable connection reuse (keep-alive)
-                // HttpURLConnection requires full response consumption before reuse
-                try (InputStream is = urlConnection.getInputStream()) {
-                    byte[] buffer = new byte[1024];
-                    while (is.read(buffer) != -1) {
-                        // Consume response data
-                    }
+                sendBuffer.setLength(0);
+                if (bufferExceeded) {
+                    errorReporter.logInfo("Send queue cleared - log messages will no longer be lost");
+                    bufferExceeded = false;
                 }
             } else {
-                String data = slurpErrors(urlConnection); 
+                String data = new String(response.body(), StandardCharsets.UTF_8);
                 if (rc >= 400 && rc < 500) {
                     errorReporter.logInfo("Send queue cleared - drop log messages due to http 4xx error.");
                     sendBuffer.setLength(0);
@@ -101,60 +129,44 @@ public class ElasticsearchWriter implements SafeWriter {
                 }
                 throw new IOException("Got response code [" + rc + "] from server with data " + data);
             }
+        } catch (URISyntaxException e) {
+            throw new IOException("Invalid URL: " + settings.getUrl(), e);
+        }
+    }
 
-            sendBuffer.setLength(0);
-            if (bufferExceeded) {
-                errorReporter.logInfo("Send queue cleared - log messages will no longer be lost");
-                bufferExceeded = false;
+    private byte[] buildBody(String body) throws IOException {
+        if (compressedTransfer) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+                gzip.write(body.getBytes(StandardCharsets.UTF_8));
             }
-        } finally {
-            // Disconnect releases this HttpURLConnection instance. When response streams were fully
-            // consumed (as above), most JDKs retain the underlying socket in the keep-alive cache
-            // for reuse; disconnect() does not necessarily close the TCP connection.
-            if (urlConnection != null) {
-                urlConnection.disconnect();
-            }
+            return baos.toByteArray();
+        }
+        return body.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static URI stripUserInfo(URI uri) throws URISyntaxException {
+        if (uri.getUserInfo() == null) {
+            return uri;
+        }
+        return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(),
+                uri.getPath(), uri.getQuery(), uri.getFragment());
+    }
+
+    private static void applyUserInfo(BasicAuthentication auth, String userInfo) {
+        String decoded = URLDecoder.decode(userInfo, StandardCharsets.UTF_8);
+        int idx = decoded.indexOf(':');
+        if (idx >= 0) {
+            auth.setUsername(decoded.substring(0, idx));
+            auth.setPassword(decoded.substring(idx + 1));
+        } else {
+            auth.setUsername(decoded);
+            auth.setPassword("");
         }
     }
 
     public boolean hasPendingData() {
         return sendBuffer.length() != 0;
-    }
-
-    protected String slurpErrors(HttpURLConnection urlConnection) {
-        try (InputStream stream = urlConnection.getErrorStream()) {
-            if (stream == null) {
-                return "<no data>";
-            }
-
-            StringBuilder builder = new StringBuilder();
-            try (InputStreamReader reader = new InputStreamReader(stream, "UTF-8")) {
-                char[] buf = new char[2048];
-                int numRead;
-                while ((numRead = reader.read(buf)) > 0) {
-                    builder.append(buf, 0, numRead);
-                }
-            }
-            return builder.toString();
-        } catch (Exception e) {
-            return "<error retrieving data: " + e.getMessage() + ">";
-        }
-    }
-
-    private void writeData(HttpURLConnection urlConnection, String body) throws IOException {
-        if (this.compressedTransfer) {
-            try (OutputStream out = urlConnection.getOutputStream();
-                 Writer writer = new OutputStreamWriter(new GZIPOutputStream(out), "UTF-8")) {
-                writer.write(body);
-                writer.flush();
-            }
-        } else {
-            try (OutputStream out = urlConnection.getOutputStream();
-                 Writer writer = new OutputStreamWriter(out, "UTF-8")) {
-                writer.write(body);
-                writer.flush();
-            }
-        }
     }
 
     public StringBuilder getSendBuffer() {

--- a/src/test/java/com/agido/logback/elasticsearch/config/AWSAuthenticationTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/config/AWSAuthenticationTest.java
@@ -1,0 +1,60 @@
+package com.agido.logback.elasticsearch.config;
+
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+
+public class AWSAuthenticationTest {
+
+    // Independent, well-known SHA-256 of the ASCII string "test".
+    private static final String SHA256_OF_TEST =
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+    // Golden SigV4 signature captured deterministically with the fixed clock + static credentials
+    // below. Pinned so future regressions in the signing path are caught.
+    private static final String GOLDEN_SIGNATURE =
+            "66cbb29c90ba6e397674b479a7092648b16d51eef2a0e0edded09c97ec2fc63f";
+
+    @Test
+    public void should_produce_deterministic_sigv4_signature() {
+        StaticCredentialsProvider creds = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+        Clock fixed = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+        AWSAuthentication auth = new AWSAuthentication(creds, Region.US_EAST_1, fixed);
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        auth.addAuth(headers,
+                URI.create("https://search-mydomain.us-east-1.es.amazonaws.com/_bulk"),
+                "test".getBytes(UTF_8));
+
+        // x-amz-content-sha256 must equal the independent known SHA-256 of "test".
+        assertThat(headers.get("X-Amz-Content-Sha256"), is(SHA256_OF_TEST));
+
+        assertTrue("X-Amz-Date should start with 20240101 but was " + headers.get("X-Amz-Date"),
+                headers.get("X-Amz-Date").startsWith("20240101"));
+
+        String authHeader = headers.get("Authorization");
+        String pattern = "^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20240101/us-east-1/es/aws4_request, "
+                + "SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$";
+        assertTrue("Authorization header did not match expected SigV4 shape: " + authHeader,
+                authHeader.matches(pattern));
+
+        // Golden equality assertion (pinned signature).
+        assertThat(authHeader, is("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20240101/us-east-1/es/aws4_request, "
+                + "SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=" + GOLDEN_SIGNATURE));
+    }
+}

--- a/src/test/java/com/agido/logback/elasticsearch/config/BasicAuthenticationTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/config/BasicAuthenticationTest.java
@@ -1,62 +1,58 @@
 package com.agido.logback.elasticsearch.config;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.junit.MockitoJUnitRunner;
 
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class BasicAuthenticationTest {
 
     @Test
-    public void should_encode_credentials_with_special_characters_using_explicit_username_password() throws Exception {
+    public void should_encode_credentials_with_special_characters_using_explicit_username_password() {
         // Given: explicit username/password with special characters
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-
         BasicAuthentication auth = new BasicAuthentication();
         auth.setUsername("user");
         auth.setPassword("p@ss€wörd#123");
 
+        Map<String, String> headers = new LinkedHashMap<>();
+
         // When
-        auth.addAuth(mockConnection, "");
+        auth.addAuth(headers, URI.create("http://localhost:9200/_bulk"), new byte[0]);
 
         // Then: verify credentials are encoded with UTF-8
-        ArgumentCaptor<String> headerValue = ArgumentCaptor.forClass(String.class);
-        verify(mockConnection).setRequestProperty(eq("Authorization"), headerValue.capture());
-
         String expectedCredentials = "user:p@ss€wörd#123";
         String expectedBase64 = Base64.getEncoder().encodeToString(expectedCredentials.getBytes(StandardCharsets.UTF_8));
-        assertThat(headerValue.getValue(), is("Basic " + expectedBase64));
+        assertThat(headers.get("Authorization"), is("Basic " + expectedBase64));
     }
 
     @Test
-    public void should_fallback_to_url_credentials_when_username_password_not_set() throws Exception {
-        // Given: URL with URL-encoded special characters (legacy mode)
-        URL testUrl = new URL("http://user:p%40ss%E2%82%ACw%C3%B6rd%23123@localhost:9200");
-        
-        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
-        when(mockConnection.getURL()).thenReturn(testUrl);
+    public void should_use_url_encoded_userinfo_decoded_the_way_the_writer_does() {
+        // The writer strips userInfo from the URL, URL-decodes it (UTF-8) and feeds the
+        // username/password setters. This test reproduces that decode step for the legacy form
+        // http://user:p%40ss%E2%82%ACw%C3%B6rd%23123@localhost:9200 and asserts the resulting header.
+        String rawUserInfo = "user:p%40ss%E2%82%ACw%C3%B6rd%23123";
+        String decoded = URLDecoder.decode(rawUserInfo, StandardCharsets.UTF_8);
+        int idx = decoded.indexOf(':');
 
         BasicAuthentication auth = new BasicAuthentication();
+        auth.setUsername(decoded.substring(0, idx));
+        auth.setPassword(decoded.substring(idx + 1));
+
+        Map<String, String> headers = new LinkedHashMap<>();
 
         // When
-        auth.addAuth(mockConnection, "");
+        auth.addAuth(headers, URI.create("http://localhost:9200/_bulk"), new byte[0]);
 
-        // Then: verify credentials are decoded and encoded with UTF-8
-        ArgumentCaptor<String> headerValue = ArgumentCaptor.forClass(String.class);
-        verify(mockConnection).setRequestProperty(eq("Authorization"), headerValue.capture());
-
+        // Then
         String expectedCredentials = "user:p@ss€wörd#123";
         String expectedBase64 = Base64.getEncoder().encodeToString(expectedCredentials.getBytes(StandardCharsets.UTF_8));
-        assertThat(headerValue.getValue(), is("Basic " + expectedBase64));
+        assertThat(headers.get("Authorization"), is("Basic " + expectedBase64));
     }
 }

--- a/src/test/java/com/agido/logback/elasticsearch/writer/ElasticsearchWriterHttpTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/writer/ElasticsearchWriterHttpTest.java
@@ -1,0 +1,153 @@
+package com.agido.logback.elasticsearch.writer;
+
+import ch.qos.logback.core.ContextBase;
+import com.agido.logback.elasticsearch.config.HttpRequestHeader;
+import com.agido.logback.elasticsearch.config.HttpRequestHeaders;
+import com.agido.logback.elasticsearch.config.Settings;
+import com.agido.logback.elasticsearch.util.ErrorReporter;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.Assert.*;
+
+public class ElasticsearchWriterHttpTest {
+
+    private WireMockServer server;
+
+    @Before
+    public void setUp() {
+        server = new WireMockServer(options().dynamicPort());
+        server.start();
+        WireMock.configureFor("localhost", server.port());
+    }
+
+    @After
+    public void tearDown() {
+        server.stop();
+    }
+
+    private Settings settings() throws Exception {
+        Settings settings = new Settings();
+        settings.setUrl(new URL("http://localhost:" + server.port() + "/_bulk"));
+        settings.setReadTimeout(5000);
+        settings.setConnectTimeout(5000);
+        return settings;
+    }
+
+    private ErrorReporter errorReporter(Settings settings) {
+        return new ErrorReporter(settings, new ContextBase());
+    }
+
+    private HttpRequestHeaders headers(String name, String value) {
+        HttpRequestHeaders headers = new HttpRequestHeaders();
+        if (name != null) {
+            HttpRequestHeader h = new HttpRequestHeader();
+            h.setName(name);
+            h.setValue(value);
+            headers.addHeader(h);
+        }
+        return headers;
+    }
+
+    private void write(ElasticsearchWriter writer, String data) {
+        writer.write(data.toCharArray(), 0, data.length());
+    }
+
+    @Test
+    public void should_post_body_with_json_content_type_on_200() throws Exception {
+        stubFor(post(urlEqualTo("/_bulk")).willReturn(aResponse().withStatus(200).withBody("ok")));
+
+        Settings settings = settings();
+        ElasticsearchWriter writer = new ElasticsearchWriter(errorReporter(settings), settings, headers(null, null));
+        write(writer, "{\"index\":{}}\n{\"message\":\"hello\"}\n");
+        writer.sendData();
+
+        assertFalse(writer.hasPendingData());
+        verify(postRequestedFor(urlEqualTo("/_bulk"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(containing("hello")));
+    }
+
+    @Test
+    public void should_throw_and_clear_buffer_on_400() throws Exception {
+        stubFor(post(urlEqualTo("/_bulk")).willReturn(aResponse().withStatus(400).withBody("bad request")));
+
+        Settings settings = settings();
+        ElasticsearchWriter writer = new ElasticsearchWriter(errorReporter(settings), settings, headers(null, null));
+        write(writer, "{\"index\":{}}\n");
+
+        try {
+            writer.sendData();
+            fail("Expected IOException on 400");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("400"));
+            assertTrue(e.getMessage().contains("bad request"));
+        }
+
+        // 4xx clears the buffer
+        assertFalse(writer.hasPendingData());
+        assertEquals(0, writer.getSendBuffer().length());
+    }
+
+    @Test
+    public void should_reuse_client_across_two_sends() throws Exception {
+        stubFor(post(urlEqualTo("/_bulk")).willReturn(aResponse().withStatus(200)));
+
+        Settings settings = settings();
+        ElasticsearchWriter writer = new ElasticsearchWriter(errorReporter(settings), settings, headers(null, null));
+
+        write(writer, "first\n");
+        writer.sendData();
+        write(writer, "second\n");
+        writer.sendData();
+
+        verify(2, postRequestedFor(urlEqualTo("/_bulk")));
+    }
+
+    @Test
+    public void should_gzip_body_when_content_encoding_gzip() throws Exception {
+        stubFor(post(urlEqualTo("/_bulk")).willReturn(aResponse().withStatus(200)));
+
+        Settings settings = settings();
+        ElasticsearchWriter writer = new ElasticsearchWriter(
+                errorReporter(settings), settings, headers("Content-Encoding", "gzip"));
+        String payload = "{\"message\":\"gzipped-payload\"}";
+        write(writer, payload);
+        writer.sendData();
+
+        List<com.github.tomakehurst.wiremock.verification.LoggedRequest> requests =
+                findAll(postRequestedFor(urlEqualTo("/_bulk")));
+        assertEquals(1, requests.size());
+
+        // The Content-Encoding: gzip header must have been sent.
+        verify(postRequestedFor(urlEqualTo("/_bulk"))
+                .withHeader("Content-Encoding", equalTo("gzip")));
+
+        byte[] received = requests.get(0).getBody();
+        boolean gzipped = received.length >= 2
+                && (received[0] & 0xff) == 0x1f && (received[1] & 0xff) == 0x8b;
+        String body;
+        if (gzipped) {
+            // Raw wire bytes: gunzip independently to recover the payload.
+            try (GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(received))) {
+                body = new String(gis.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } else {
+            // WireMock already transparently decompressed the gzip body.
+            body = new String(received, StandardCharsets.UTF_8);
+        }
+        assertEquals(payload, body);
+    }
+}

--- a/src/test/java/com/agido/logback/elasticsearch/writer/ElasticsearchWriterHttpTest.java
+++ b/src/test/java/com/agido/logback/elasticsearch/writer/ElasticsearchWriterHttpTest.java
@@ -150,4 +150,30 @@ public class ElasticsearchWriterHttpTest {
         }
         assertEquals(payload, body);
     }
+
+    @Test
+    public void should_use_url_userinfo_for_basic_auth_end_to_end() throws Exception {
+        // Legacy form: credentials embedded in the URL userInfo (URL-encoded UTF-8), no explicit
+        // username/password configured. The writer must (a) strip userInfo before handing the URI to
+        // java.net.http.HttpClient (which rejects userInfo URIs) and (b) decode it and feed
+        // BasicAuthentication so the Authorization header is actually sent. This is the integrated
+        // replacement for the old BasicAuthentication "fallback to URL credentials" unit test.
+        stubFor(post(urlEqualTo("/_bulk")).willReturn(aResponse().withStatus(200)));
+
+        Settings settings = new Settings();
+        settings.setUrl(new URL("http://user:p%40ss%E2%82%ACw%C3%B6rd%23123@localhost:" + server.port() + "/_bulk"));
+        settings.setReadTimeout(5000);
+        settings.setConnectTimeout(5000);
+        settings.setAuthentication(new com.agido.logback.elasticsearch.config.BasicAuthentication());
+
+        ElasticsearchWriter writer = new ElasticsearchWriter(errorReporter(settings), settings, headers(null, null));
+        write(writer, "{\"index\":{}}\n");
+        writer.sendData(); // must NOT throw: userInfo is stripped before HttpClient sees the URI
+
+        assertFalse(writer.hasPendingData());
+        String expected = "Basic " + java.util.Base64.getEncoder()
+                .encodeToString("user:p@ss€wörd#123".getBytes(StandardCharsets.UTF_8));
+        verify(postRequestedFor(urlEqualTo("/_bulk"))
+                .withHeader("Authorization", equalTo(expected)));
+    }
 }


### PR DESCRIPTION
Resolves #45 (together with #48, which does the Java 11 upgrade this builds on).

This replaces the legacy `java.net.HttpURLConnection` transport with a reused `java.net.http.HttpClient` (Java 11+), which gives connection pooling / keep-alive automatically — the "use HttpClient for connection pooling" half of #45 — and migrates the AWS SigV4 signing from AWS SDK **v1** to **v2**.

### Changes
- **`ElasticsearchWriter`** — a single reused `HttpClient` instance (the connection pool); userInfo is stripped from the URI before sending (HttpClient rejects userInfo URIs); gzip transfer and the existing 200 / 4xx / error-response semantics are preserved.
- **`AWSAuthentication`** — rewritten on AWS SDK v2 (`Aws4Signer`), service `es`. The ~50-line hand-rolled `URLConnectionSignableRequest` adapter (which coupled signing to `HttpURLConnection`) is deleted; v2 signs a client-agnostic request.
- **`Authentication`** interface — now header-map based (`addAuth(Map<String,String>, URI, byte[])`), decoupled from any HTTP client.
- **`pom.xml`** — drop `com.amazonaws:aws-java-sdk-core` (v1); add `software.amazon.awssdk:auth` + `regions` (BOM 2.28.16, `provided` scope, matching how the v1 SDK was provided).

### Tests (all green under Temurin 11 — `mvn test`)
- All pre-existing tests still pass; `ElasticsearchAppenderTest`, `ConcurrentPublisherTest`, `PropertySerializerTest` are untouched.
- **SigV4 known-answer** test — fixed credentials + frozen clock; asserts `x-amz-content-sha256` equals the independent SHA-256 of the payload and the full `Authorization` shape/signature.
- **WireMock transport** tests — 200 path + JSON content-type, 4xx throws and clears the buffer, client reuse across two sends, and gzip round-trip.
- **End-to-end userInfo → Basic auth** test — a `user:pass@host` URL with no explicit credentials: verifies the writer strips userInfo for HttpClient *and* still sends the correct `Authorization` header.

*Prepared with the open-source [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill (Java 11 hop) plus a hand-written, fully-tested HttpClient + AWS SDK v2 refactor.*
